### PR TITLE
Enhance an unify doc in READMEs

### DIFF
--- a/bludit/README.md
+++ b/bludit/README.md
@@ -4,16 +4,18 @@ E2E Web Testing benchmark
 Gherkin specifications for Bludit
 ----------------------
 
-This directory contains Gherkin speficiations for testing Bludit 2.3.4.
+[Bludit](https://www.bludit.com/) is an open-source flat-file Content Management System (CMS) and blogging platform.
+
+This directory contains Gherkin specifications for testing Bludit 2.3.4.
 
 # Deployment instructions
 The Docker container for the application under test can be created using the following commands:
 
 ```bash
-docker run --name bludit -p 8080:80 -d bludit/docker:2.3.4
+docker run --rm -it --name bludit -p 8080:80 bludit/docker:2.3.4
 ```
 
-The web application will be exposed on `localhost:8080`. 
+The web application will be exposed on http://localhost:8080
 
 # Installation instructions
 

--- a/claroline/README.md
+++ b/claroline/README.md
@@ -4,14 +4,18 @@ E2E Web Testing benchmark
 Gherkin specifications for Claroline
 ----------------------
 
-This directory contains Gherkin speficiations for Claroline.
+[Claroline](https://www.claroline.com/) is an open-source e-learning platform designed to facilitate online learning and collaboration.
+
+This directory contains Gherkin specifications for Claroline 1.11.10.
 
 # Deployment instructions
 The Docker container for the application under test can be created using the following commands:
 
 ```bash
-docker run -it --workdir=/home/claroline --name=claroline --expose 80 --expose 3306 -p 3000:80 -p 3306:3306 -d --entrypoint ./run-services-docker.sh dockercontainervm/claroline:1.11.10 bash
+docker run --rm -it --workdir=/home/claroline --name=claroline --expose 80 --expose 3306 -p 3000:80 -p 3306:3306 --entrypoint ./run-services-docker.sh dockercontainervm/claroline:1.11.10 bash
 ```
 
-The web application will be exposed on `localhost:3000`. The application is ready to use when the container is started, no post-installation steps are required.
+The web application will be exposed on http://localhost:3000
+
+The application is ready to use when the container is started, no post-installation steps are required.
 

--- a/expresscart/README.md
+++ b/expresscart/README.md
@@ -4,14 +4,18 @@ E2E Web Testing benchmark
 Gherkin specifications for ExpressCart
 ----------------------
 
-This directory contains Gherkin speficiations for ExpressCart 1.19.
+[ExpressCart](https://expresscart.markmoffat.com/) is an open-source, Node.js-based e-commerce platform.
+
+This directory contains Gherkin specifications for ExpressCart 1.19.
 
 # Deployment instructions
 The Docker container for the application under test can be created using the following command:
 
 ```bash
-docker run -i -t  --name=expresscart -p "3000:1111" -d olianasd/expresscart-mongodb
+docker run --rm -it --name=expresscart -p "3000:1111" olianasd/expresscart-mongodb
 ```
 
-The web application will be exposed on `localhost:3000`. The application is ready to use when the container is started, no post-installation steps are required.
+The web application will be exposed on http://localhost:3000
+
+The application is ready to use when the container is started, no post-installation steps are required.
 

--- a/joomla/README.md
+++ b/joomla/README.md
@@ -4,7 +4,9 @@ E2E Web Testing benchmark
 Gherkin specifications for Joomla
 ----------------------
 
-This directory contains Gherkin speficiations and automated installer for Joomla 3.10.11.
+[Joomla](https://www.joomla.org/) an open-source Content Management System (CMS).
+
+This directory contains Gherkin specifications and automated installer for [Joomla](https://www.joomla.org/) 3.10.11.
 
 # Deployment instructions
 The Docker containers for Joomla 3.10.11 can be created using the `docker-compose.yml` file contained in this directory. Just move into the directory using a terminal and type:
@@ -12,7 +14,10 @@ The Docker containers for Joomla 3.10.11 can be created using the `docker-compos
 ```bash
 docker compose up
 ```
-The web application will be exposed on `localhost:8080`. After the containers are deployed, an installation wizard must be followed. Please refer to the further section **Installation instructions**
+
+The web application will be exposed on http://localhost:8080
+
+After the containers are deployed, an installation wizard must be followed. Please refer to the further section **Installation instructions**
 
 # Installation instructions
 

--- a/kanboard/README.md
+++ b/kanboard/README.md
@@ -4,15 +4,19 @@ E2E Web Testing benchmark
 Gherkin specifications for Kanboard
 ----------------------
 
-This directory contains Gherkin speficiations for Kanboard 1.2.15.
+
+[Kanboard](https://kanboard.org/) is an open-source project management software designed to facilitate task tracking and project management using the Kanban methodology.
+
+This directory contains Gherkin specifications for Kanboard 1.2.15.
 
 # Deployment instructions
 The Docker container for the application under test can be created using the following command:
 
 ```bash
-docker run -d --name kanboard -p 8080:80 -t kanboard/kanboard:v1.2.15
-
+docker run --rm -it --name kanboard -p 8080:80 -t kanboard/kanboard:v1.2.15
 ```
 
-The web application will be exposed on `localhost:8080`. The application is ready to use when the container is started, no post-installation steps are required.
+The web application will be exposed on http://localhost:8080
+
+The application is ready to use when the container is started, no post-installation steps are required.
 

--- a/mantisbt/README.md
+++ b/mantisbt/README.md
@@ -4,13 +4,17 @@ E2E Web Testing benchmark
 Gherkin specifications for MantisBT
 ----------------------
 
-This directory contains Gherkin speficiations for MantisBT 1.2.0.
+[MantisBT](https://mantisbt.org/), short for Mantis Bug Tracker, is an open-source web-based issue tracking system designed to help teams manage software development projects more effectively.
 
+This directory contains Gherkin specifications for MantisBT 1.2.0.
 
 # Deployment instructions for MantisBT 1.2.0
 The Docker container for the application under test can be created using the following command:
 
 ```bash
-docker run -it --workdir=/home --name=mantisbt --expose 80 --expose 3306 -p 3000:80 -p 3306:3306 -d --entrypoint ./run-services-docker.sh dockercontainervm/mantisbt:1.2.0 bash
+docker run --rm -it --workdir=/home --name=mantisbt --expose 80 --expose 3306 -p 3000:80 -p 3306:3306 --entrypoint ./run-services-docker.sh dockercontainervm/mantisbt:1.2.0 bash
 ```
-The web application will be exposed on `localhost:3000/mantisbt`. The application is ready to use when the container is started, no post-installation steps are required.
+
+The web application will be exposed on http://localhost:3000/mantisbt
+
+The application is ready to use when the container is started, no post-installation steps are required.

--- a/mediawiki/README.md
+++ b/mediawiki/README.md
@@ -1,20 +1,23 @@
 E2E Web Testing benchmark
 =========================
 
-Gherkin specifications for Mediawiki
+Gherkin specifications for MediaWiki
 ----------------------
 
-This directory contains Gherkin speficiations and an automated installer for Mediawiki.
+[MediaWiki](https://www.mediawiki.org/wiki/MediaWiki) is an and open-source wiki software package written in PHP. Originally developed for Wikipedia, it now powers many other wikis.
+
+This directory contains Gherkin specifications and an automated installer for MediaWiki 1.40.0.
 
 # Deployment instructions
-The Docker containers for Mediawiki can be created using the `docker-compose.yml` file contained in this direcctory. Just move into the directory using a terminal and type:
+The Docker containers for MediaWiki can be created using the `docker-compose.yml` file contained in this directory. Just move into the directory using a terminal and type:
 
 ```bash
 docker compose up
 ```
 
+The web application will be exposed on http://localhost:8080
 
-The web application will be exposed on `localhost:8080`. An installation wizard must be followed after deploying the container.
+An installation wizard must be followed after deploying the container.
 
 # Installation instructions
 

--- a/prestashop/README.md
+++ b/prestashop/README.md
@@ -1,24 +1,25 @@
 E2E Web Testing benchmark
 =========================
 
-Gherkin specifications for Prestashop
+Gherkin specifications for PrestaShop
 ----------------------
 
-This directory contains Gherkin speficiations and an automated installer for Prestashop.
+[PrestaShop](https://prestashop.com/) is an open-source e-commerce platform used for building and managing online stores.
+
+This directory contains Gherkin specializations and an automated installer for PrestaShop 1.6.1.23.
 
 # Deployment instructions
 The Docker containers for the application under test can be created using the following commands:
 
-
 ```bash
-#Prestashop 1.6.1.23
-docker network create prestashop-net 
-docker run -ti --name some-mysql --network prestashop-net -e MYSQL_ROOT_PASSWORD=admin -p 3307:3306 -d mysql:5.7
-docker run -ti --name some-prestashop --network prestashop-net -e DB_SERVER=some-mysql -p 8080:80 -d prestashop/prestashop:1.6.1.23
+docker network create prestashop-net
+docker run --rm -it --name some-mysql --network prestashop-net -e MYSQL_ROOT_PASSWORD=admin -p 3307:3306 mysql:5.7
+docker run --rm -it --name some-prestashop --network prestashop-net -e DB_SERVER=some-mysql -p 8080:80 prestashop/prestashop:1.6.1.23
 ```
 
+The web application will be exposed on http://localhost:8080
 
-The web application will be exposed on `localhost:8080`. After the containers are deployed, an installation wizard must be followed
+After the containers are deployed, an installation wizard must be followed
 
 # Installation instructions
 The installation wizard can be executed automatically by running `InstallerTest.install` (located in the Maven project `prestashop-installer-1.6.1.23`) as a JUnit test. You can run it with Maven using the command 


### PR DESCRIPTION
This PR updates the README for all the web applications under study. In particular:

- In includes a line to describe the web application (e.g., PrestaShop is an open-source e-commerce platform...).
- It specifies using the flag `--rm` instead of `-d` in Docker commands to easily stop and remove containers by using Ctrl+C in the shell (instead of `docker stop` plus `docker rm`).
- It includes the web applications version when missing.
- It fixes some minor typos.